### PR TITLE
feat(generator): Playwright spec generator (Task B)

### DIFF
--- a/src/test_helper/services/generator_service.py
+++ b/src/test_helper/services/generator_service.py
@@ -1,0 +1,124 @@
+"""Playwright test code generator service.
+
+Converts standardized interaction trace events into Playwright Test (TypeScript)
+spec files and writes them to the project tests directory.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from test_helper.utils.settings import get_e2e_settings
+
+_TEMPLATE_TS = """import {{ test, expect }} from '@playwright/test';
+
+test('{name}', async ({{ page }}) => {{
+  {body}
+}});
+"""
+
+if TYPE_CHECKING:  # pragma: no cover - type-only imports
+    from collections.abc import Iterable
+
+    from test_helper.services.mcp_client import InteractionEvent
+
+
+def _escape_single_quotes(value: str) -> str:
+    """Escape single quotes for safe inclusion in single-quoted TS strings."""
+    return value.replace("'", "\\'")
+
+
+def _to_locator(e: InteractionEvent) -> str:
+    """Build a Playwright locator expression from an interaction event payload."""
+    payload = e.payload
+    selector = payload.get("selector")
+    if selector:
+        return f"page.locator('{_escape_single_quotes(selector)}')"
+
+    role = payload.get("role")
+    if role:
+        name = payload.get("name")
+        if name:
+            return (
+                "page.getByRole('"
+                + _escape_single_quotes(str(role))
+                + "', { name: '"
+                + _escape_single_quotes(str(name))
+                + "' })"
+            )
+        return f"page.getByRole('{_escape_single_quotes(str(role))}')"
+
+    # Fallback to body
+    return "page.locator('body')"
+
+
+def render_spec_ts(events: Iterable[InteractionEvent], name: str) -> str:
+    """Render a Playwright Test spec (.spec.ts) from interaction events.
+
+    Args:
+        events: Iterable of standardized interaction events.
+        name: Test name (used in the `test()` block title).
+
+    Returns:
+        The TypeScript code as a string.
+
+    """
+    lines: list[str] = []
+    for e in events:
+        if e.type == "navigate":
+            url = _escape_single_quotes(str(e.payload.get("url", "")))
+            lines.append(f"await page.goto('{url}');")
+        elif e.type == "click":
+            lines.append(f"await {_to_locator(e)}.click();")
+        elif e.type == "fill":
+            sel = _escape_single_quotes(str(e.payload.get("selector", "")))
+            val = _escape_single_quotes(str(e.payload.get("value", "")))
+            lines.append(f"await page.fill('{sel}', '{val}');")
+        elif e.type == "assert":
+            lines.append(f"await expect({_to_locator(e)}).toBeVisible();")
+        else:
+            # Unknown event types are ignored to keep generator robust
+            continue
+
+    body = "\n  ".join(lines)
+    # Escape single quotes in test name as well
+    safe_name = _escape_single_quotes(name)
+    return _TEMPLATE_TS.format(name=safe_name, body=body)
+
+
+def _sanitize_filename(name: str) -> str:
+    """Sanitize a test name for filesystem-friendly file names."""
+    import re
+
+    lowered = name.strip().lower()
+    lowered = lowered.replace(" ", "_")
+    return re.sub(r"[^a-z0-9_\-]", "", lowered)
+
+
+def write_spec(project_id: str, name: str, code: str) -> str:
+    """Write the generated TypeScript code into the project's tests directory.
+
+    The file will be placed under: `data/projects/{project_id}/tests/` by default,
+    where `data` is configurable via E2E settings.
+
+    Args:
+        project_id: E2E project identifier.
+        name: Test name (used to build file name).
+        code: The TypeScript test code to write.
+
+    Returns:
+        The absolute path to the written file, as a string.
+
+    """
+    settings = get_e2e_settings()
+    base: Path = Path(settings.e2e_data_path) / "projects" / project_id / "tests"
+    base.mkdir(parents=True, exist_ok=True)
+
+    filename = f"test_{_sanitize_filename(name)}.spec.ts"
+    file_path = base / filename
+    file_path.write_text(code, encoding="utf-8")
+    return str(file_path)
+
+
+__all__ = ["render_spec_ts", "write_spec"]

--- a/src/test_helper/services/mcp_client.py
+++ b/src/test_helper/services/mcp_client.py
@@ -1,0 +1,31 @@
+"""Minimal MCP client types used across services.
+
+This module provides the `InteractionEvent` model that represents a single
+standardized user interaction captured during UI automation. The full MCP
+client is out of scope here; we only define what's needed for code generation
+and tests.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class InteractionEvent(BaseModel):
+    """A standardized interaction event.
+
+    Attributes:
+        type: The event type (e.g., "navigate", "click", "fill", "assert").
+        payload: The event payload, such as {"url": "..."} for navigate,
+                 {"selector": "#id"} for click/fill, or {"role": "button", "name": "..."}
+                 for role-based targeting.
+
+    """
+
+    type: str
+    payload: dict[str, Any]
+
+
+__all__ = ["InteractionEvent"]

--- a/tests/unit/services/test_generator_service.py
+++ b/tests/unit/services/test_generator_service.py
@@ -1,0 +1,56 @@
+"""Unit tests for Playwright test code generator service."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from test_helper.services.generator_service import render_spec_ts, write_spec
+from test_helper.services.mcp_client import InteractionEvent
+from test_helper.utils.settings import get_e2e_settings, reset_e2e_settings
+
+
+def test_render_spec_ts_basic_mappings() -> None:
+    """Ensure navigate/click/fill/assert map to TS correctly."""
+    events = [
+        InteractionEvent(type="navigate", payload={"url": "https://example.com"}),
+        InteractionEvent(type="click", payload={"selector": "#login"}),
+        InteractionEvent(
+            type="fill",
+            payload={"selector": "#user", "value": "alice"},
+        ),
+        InteractionEvent(
+            type="assert",
+            payload={"role": "heading", "name": "Dashboard"},
+        ),
+    ]
+
+    code = render_spec_ts(events, name="Login flow")
+
+    assert "test('Login flow', async ({ page }) => {" in code
+    assert "await page.goto('https://example.com');" in code
+    assert "await page.locator('#login').click();" in code
+    assert "await page.fill('#user', 'alice');" in code
+    assert (
+        "await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();"
+        in code
+    )
+
+
+def test_write_spec_creates_file_in_project_tests_dir(temp_dir: Path) -> None:
+    """write_spec should create file in data/projects/{id}/tests/ with sanitized name."""
+    # Isolate E2E settings to the temp directory
+    reset_e2e_settings()
+    s = get_e2e_settings()
+    s.e2e_data_path = temp_dir
+
+    code = "import { test } from '@playwright/test';\n"
+    project_id = "proj123"
+    name = "My Spec"
+    path_str = write_spec(project_id, name, code)
+
+    expected_path = (
+        temp_dir / "projects" / project_id / "tests" / "test_my_spec.spec.ts"
+    )
+    assert Path(path_str) == expected_path
+    assert expected_path.exists()
+    assert expected_path.read_text(encoding="utf-8") == code


### PR DESCRIPTION
Implements Task B: 操作トレース → Playwright テストコード生成器.\n\n- Adds generator service to render Playwright *.spec.ts from InteractionEvent[]\n- Persists specs to data/projects/{id}/tests/ via settings\n- Includes unit tests for mapping and file output\n- CI (nox) passing: lint, format, typing, tests, security\n\nPlease review locator strategy and naming conventions; happy to iterate.